### PR TITLE
Fix the "with an assembly" example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ services.AddMediatR(typeof(MyHander));
 or with an assembly:
 
 ```
-services.AddMediatR(typeof(Startup).Assembly);
+services.AddMediatR(typeof(Startup).GetTypeInfo().Assembly);
 ```
 
 Supports generic variance of handlers.


### PR DESCRIPTION
.Assembly not available on Core. Added GetTypeInfo() as per sample app.