### PR TITLE
Make instance resolution optional to support MediatR 3

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -369,14 +369,9 @@
 
         private static void AddRequiredServices(IServiceCollection services)
         {
-            services.AddScoped<SingleInstanceFactory>(p => t => p.GetRequiredService(t));
-            services.AddScoped<MultiInstanceFactory>(p => t => p.GetRequiredServices(t));
+            services.AddScoped<SingleInstanceFactory>(p => t => p.GetService(t));
+            services.AddScoped<MultiInstanceFactory>(p => t => p.GetServices(t));
             services.AddScoped<IMediator, Mediator>();
-        }
-
-        private static IEnumerable<object> GetRequiredServices(this IServiceProvider provider, Type serviceType)
-        {
-            return (IEnumerable<object>)provider.GetRequiredService(typeof(IEnumerable<>).MakeGenericType(serviceType));
         }
     }
 }


### PR DESCRIPTION
As MediatR 3 uses bruteforce to resolve sync, async and cancellable request
handlers, make their resolution optional:
[`RequestHandler.cs#L95-L126`](https://github.com/jbogard/MediatR/blob/779ae218eceacb238baa61c0369ce0edfe4874ba/src/MediatR/Internal/RequestHandler.cs#L95-L126)

I admit I didn't try building this but I copied the relevant code to my own project and it seems to work. Please forgive :innocent: