### PR TITLE
Crash during setup by adding generic message/handler pairs

### DIFF
--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
@@ -49,6 +49,16 @@
 
     }
 
+    public class GenericPing<T> : IRequest<GenericPong<T>>
+    {
+        public T Message { get; set; }
+    }
+
+    public class GenericPong<T>
+    {
+        public T Response { get; set; }
+    }
+
     public class GenericAsyncHandler : IAsyncNotificationHandler<INotification>
     {
         public Task Handle(INotification notification)
@@ -152,4 +162,11 @@
         }
     }
 
+    public class GenericPingHandler<T> : IRequestHandler<GenericPing<T>, GenericPong<T>>
+    {
+        public GenericPong<T> Handle(GenericPing<T> message)
+        {
+            return new GenericPong<T> { Response = message.Message };
+        }
+    }
 }


### PR DESCRIPTION
As noted in #12, service registration crashes miserably when there are generic message/handler pairs like this.

From what I understand of the error message, the problem is that the setup of the container actually tries to instantiate the handler, and `T` is not known at the time, but I can't figure why it's not lazy.