### PR TITLE
Derivingrequests

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -164,9 +164,7 @@
                     {
                         if (matches.Count() > 1)
                         {
-                            // if there are multiple matches, only keep the one that fits exactly (T2 == T1)
-                            // assumes @interface is of type IRequestHandler<T1,...> and @match is of a derived type of AsyncRequestHandler<T2,...>
-                            matches.RemoveAll(m => !m.BaseType.GenericTypeArguments[0].Equals(@interface.GenericTypeArguments[0]));
+                            matches.RemoveAll(m => !IsMatchingWithInterface(m, @interface));
                         }
 
                         matches.ForEach(match => services.TryAddTransient(@interface, match));
@@ -178,6 +176,28 @@
                     }
                 }
             }
+        }
+
+        private static bool IsMatchingWithInterface(Type handlerType, Type handlerInterface)
+        {
+            if (handlerType == null || handlerInterface == null)
+            {
+                return false;
+            }
+
+            if (handlerType.IsInterface)
+            {
+                if (handlerType.GenericTypeArguments.SequenceEqual(handlerInterface.GenericTypeArguments))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                return IsMatchingWithInterface(handlerType.GetInterface(handlerInterface.Name), handlerInterface);
+            }
+
+            return false;
         }
 
         private static void AddConcretionsThatCouldBeClosed(Type @interface, List<Type> concretions, IServiceCollection services)

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -158,6 +158,10 @@
 
                     if (addIfAlreadyExists)
                     {
+                        matches.ForEach(match => services.AddTransient(@interface, match));
+                    }
+                    else
+                    {
                         if (matches.Count() > 1)
                         {
                             // if there are multiple matches, only keep the one that fits exactly (T2 == T1)
@@ -165,10 +169,6 @@
                             matches.RemoveAll(m => !m.BaseType.GenericTypeArguments[0].Equals(@interface.GenericTypeArguments[0]));
                         }
 
-                        matches.ForEach(match => services.AddTransient(@interface, match));
-                    }
-                    else
-                    {
                         matches.ForEach(match => services.TryAddTransient(@interface, match));
                     }
 

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/DerivingRequestsTests.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/DerivingRequestsTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
+{
+    public class DerivingRequestsTests
+    {
+        private readonly IServiceProvider _provider;
+        private readonly IMediator _mediator;
+
+        public DerivingRequestsTests()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+            services.AddMediatR(typeof(Ping));
+            _provider = services.BuildServiceProvider();
+            _mediator = _provider.GetRequiredService<IMediator>();
+        }
+
+        [Fact]
+        public async Task ShouldReturnPingPong()
+        {
+            Pong pong = await _mediator.Send(new Ping() { Message = "Ping" });
+            pong.Message.ShouldBe("Ping Pong");
+        }
+
+        [Fact]
+        public async Task ShouldReturnDerivedPingPong()
+        {
+            Pong pong = await _mediator.Send(new DerivedPing() { Message = "Ping" });
+            pong.Message.ShouldBe("DerivedPing Pong");
+        }
+    }
+}

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
@@ -9,6 +9,10 @@
         public string Message { get; set; }
     }
 
+    public class DerivedPing : Ping
+    {
+    }
+
     public class Pong
     {
         public string Message { get; set; }
@@ -82,6 +86,21 @@
         {
             _logger.Messages.Add("Handler");
             return Task.FromResult(new Pong { Message = message.Message + " Pong" });
+        }
+    }
+
+    public class DerivedPingHandler : IRequestHandler<DerivedPing, Pong>
+    {
+        private readonly Logger _logger;
+
+        public DerivedPingHandler(Logger logger)
+        {
+            _logger = logger;
+        }
+        public Task<Pong> Handle(DerivedPing message, CancellationToken cancellationToken)
+        {
+            _logger.Messages.Add("Handler");
+            return Task.FromResult(new Pong { Message = $"Derived{message.Message} Pong" });
         }
     }
 


### PR DESCRIPTION
IRequest should match the correct handler. Necessary when you derive from an IRequest.