### PR TITLE
Only registering each assembly once to prevent duplicates

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -77,7 +77,7 @@ namespace MediatR
 
         private static void AddMediatRClasses(IServiceCollection services, IEnumerable<Assembly> assembliesToScan)
         {
-            assembliesToScan = assembliesToScan as Assembly[] ?? assembliesToScan.ToArray();
+            assembliesToScan = (assembliesToScan as Assembly[] ?? assembliesToScan).Distinct().ToArray();
 
             var openRequestInterfaces = new[]
             {

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/DuplicateAssemblyResolutionTests.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/DuplicateAssemblyResolutionTests.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
+{
+    using System;
+    using System.Linq;
+    using Shouldly;
+    using Xunit;
+
+    public class DuplicateAssemblyResolutionTests
+    {
+        private readonly IServiceProvider _provider;
+
+        public DuplicateAssemblyResolutionTests()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+            services.AddMediatR(typeof(Ping), typeof(Ping));
+            _provider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void ShouldResolveNotificationHandlersOnlyOnce()
+        {
+            _provider.GetServices<INotificationHandler<Pinged>>().Count().ShouldBe(3);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #36 