### PR TITLE
Support to custom IMediator implementation and tests

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
@@ -1,0 +1,47 @@
+﻿namespace MediatR
+{
+    using System;
+
+    public class MediatrServiceConfiguration
+    {
+        public Type MediatorImpl { get; private set; }
+        public Lifetime Lifetime { get; private set; }
+
+        public MediatrServiceConfiguration()
+        {
+            MediatorImpl = typeof(Mediator);
+            Lifetime = Lifetime.Scopped;
+        }
+
+        public MediatrServiceConfiguration Using<TMediator>() where TMediator : IMediator
+        {
+            MediatorImpl = typeof(TMediator);
+            return this;
+        }
+
+        public MediatrServiceConfiguration AsSingleton()
+        {
+            Lifetime = Lifetime.Singleton;
+            return this;
+        }
+
+        public MediatrServiceConfiguration AsScopped()
+        {
+            Lifetime = Lifetime.Scopped;
+            return this;
+        }
+
+        public MediatrServiceConfiguration AsTransient()
+        {
+            Lifetime = Lifetime.Transient;
+            return this;
+        }
+    }
+
+    public enum Lifetime
+    {
+        Singleton,
+        Scopped,
+        Transient
+    }
+}

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,14 +1,12 @@
-﻿using System.Collections;
-
 namespace MediatR
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using Pipeline;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Pipeline;
 
     /// <summary>
     /// Extensions to scan for MediatR handlers and registers them.
@@ -21,31 +19,55 @@ namespace MediatR
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        public static readonly MediatrServiceConfiguration Configuration = new MediatrServiceConfiguration();
+
         /// <summary>
         /// Registers handlers and the mediator types from <see cref="AppDomain.CurrentDomain"/>.
         /// </summary>
         /// <param name="services">Service collection</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services)
-            => services.AddMediatR(AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic));
+            => services.AddMediatR(AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic), configuration: null);
+
+        /// <summary>
+        /// Registers handlers and the mediator types from <see cref="AppDomain.CurrentDomain"/>.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="configuration">The action used to configure the options</param>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatrServiceConfiguration> configuration)
+            => services.AddMediatR(AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic), configuration);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
         /// </summary>
         /// <param name="services">Service collection</param>
-        /// <param name="assemblies">Assemblies to scan</param>
+        /// <param name="assemblies">Assemblies to scan</param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Assembly[] assemblies)
-            => services.AddMediatR(assemblies.AsEnumerable());
+            => services.AddMediatR(assemblies.AsEnumerable(), configuration: null);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
         /// </summary>
         /// <param name="services">Service collection</param>
         /// <param name="assemblies">Assemblies to scan</param>
+        /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies)
+        public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatrServiceConfiguration> configuration, params Assembly[] assemblies)
+            => services.AddMediatR(assemblies.AsEnumerable(), configuration);
+
+        /// <summary>
+        /// Registers handlers and mediator types from the specified assemblies
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="assemblies">Assemblies to scan</param>
+        /// <param name="configuration">The action used to configure the options</param>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatrServiceConfiguration> configuration)
         {
+            configuration?.Invoke(Configuration);
+
             AddRequiredServices(services);
 
             AddMediatRClasses(services, assemblies);
@@ -57,19 +79,31 @@ namespace MediatR
         /// Registers handlers and mediator types from the assemblies that contain the specified types
         /// </summary>
         /// <param name="services"></param>
-        /// <param name="handlerAssemblyMarkerTypes"></param>
+        /// <param name="handlerAssemblyMarkerTypes"></param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Type[] handlerAssemblyMarkerTypes)
-            => services.AddMediatR(handlerAssemblyMarkerTypes.AsEnumerable());
+            => services.AddMediatR(handlerAssemblyMarkerTypes.AsEnumerable(), configuration: null);
+        
+        /// <summary>
+        /// Registers handlers and mediator types from the assemblies that contain the specified types
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="handlerAssemblyMarkerTypes"></param>
+        /// <param name="configuration">The action used to configure the options</param>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatrServiceConfiguration> configuration, params Type[] handlerAssemblyMarkerTypes)
+            => services.AddMediatR(handlerAssemblyMarkerTypes.AsEnumerable(), configuration);
 
         /// <summary>
         /// Registers handlers and mediator types from the assemblies that contain the specified types
         /// </summary>
         /// <param name="services"></param>
         /// <param name="handlerAssemblyMarkerTypes"></param>
+        /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes)
+        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatrServiceConfiguration> configuration)
         {
+            configuration?.Invoke(Configuration);
             AddRequiredServices(services);
             AddMediatRClasses(services, handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly));
             return services;
@@ -305,7 +339,8 @@ namespace MediatR
                                 {
                                     var closedImplType = service.ImplementationType.MakeGenericType(serviceType.GenericTypeArguments);
                                     serviceTypes.Add(closedImplType);
-                                } catch { }
+                                }
+                                catch { }
                             }
                         }
 
@@ -315,7 +350,7 @@ namespace MediatR
                         }, ServiceLifetime.Transient));
 
                         var resolved = Array.CreateInstance(serviceType, serviceTypes.Count);
-                        
+
                         Array.Copy(serviceTypes.Select(p.GetService).ToArray(), resolved, serviceTypes.Count);
 
                         return resolved;
@@ -324,7 +359,19 @@ namespace MediatR
                     throw;
                 }
             }));
-            services.AddScoped<IMediator, Mediator>();
+            switch (Configuration.Lifetime)
+            {
+                default:
+                case Lifetime.Scopped:
+                    services.AddScoped(typeof(IMediator), Configuration.MediatorImpl);
+                    break;
+                case Lifetime.Transient:
+                    services.AddTransient(typeof(IMediator), Configuration.MediatorImpl);
+                    break;
+                case Lifetime.Singleton:
+                    services.AddSingleton(typeof(IMediator), Configuration.MediatorImpl);
+                    break;
+            }
         }
     }
 }

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/CustomMediatorTests.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/CustomMediatorTests.cs
@@ -1,0 +1,43 @@
+﻿#if NETCOREAPP2_1
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
+{
+    using System;
+    using System.Linq;
+    using Shouldly;
+    using Xunit;
+
+    public class CustomMediatorTests
+    {
+        private readonly IServiceProvider _provider;
+
+        public CustomMediatorTests()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+            services.AddMediatR(cfg => cfg.Using<MyCustomMediator>());
+            _provider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void ShouldResolveMediator()
+        {
+            _provider.GetService<IMediator>().ShouldNotBeNull();
+            _provider.GetService<IMediator>().GetType().ShouldBe(typeof(MyCustomMediator));
+        }
+
+        [Fact]
+        public void ShouldResolveRequestHandler()
+        {
+            _provider.GetService<IRequestHandler<Ping, Pong>>().ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ShouldResolveNotificationHandlers()
+        {
+            _provider.GetServices<INotificationHandler<Pinged>>().Count().ShouldBe(3);
+        }
+    }
+}
+#endif

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
@@ -140,4 +140,18 @@
     {
         public Task<Unit> Handle(InternalPing request, CancellationToken cancellationToken) => Unit.Task;
     }
+
+    class MyCustomMediator : IMediator
+    {
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
 }


### PR DESCRIPTION
```
ME as Developer
WHEN I'm registering my application dependencies
THEN I'd like to specify my custom implementation of `IMediator`
AND its life cycle as I wish.
```

Expectation:
```
services.AddMediatR(cfg => cfg.Using<MyCustomMediator>());
``` 

Follow up issue: [Add ability to specify custom IMediator implementation](https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/42)