### PR TITLE
Add behaviors registration for certain request types

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/BehaviorRegistrar.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/BehaviorRegistrar.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Registration
+{
+    public static class BehaviorRegistrar
+    {
+        public static void RegisterBehaviorForCovariantRequest(
+            Type assignableRequestType,
+            IServiceCollection services,
+            IEnumerable<Assembly> assembliesToScan)
+        {
+            var behaviorTypes = new List<Type>();
+            var requestResponseTypes = new List<(Type requestType, Type responseType)>();
+
+            foreach (var type in assembliesToScan.SelectMany(a => a.DefinedTypes).Where(t => t.IsConcrete()))
+            {
+                if (assignableRequestType.IsAssignableFrom(type))
+                {
+                    var requestInterfaceType =
+                        GetRequestInterfaceType(type, typeof(IRequest<>)) ??
+                        GetRequestInterfaceType(assignableRequestType, typeof(IRequest<>));
+
+                    if (requestInterfaceType != null)
+                    {
+                        requestResponseTypes.Add((type, requestInterfaceType.GenericTypeArguments[0]));
+                    }
+                }
+
+                var isTypeBehavior = type.GetInterfaces().Any(
+                    x => x.IsGenericType
+                         && x.GetGenericTypeDefinition() == typeof(IPipelineBehavior<,>)
+                         && x.GenericTypeArguments[0] == assignableRequestType);
+
+                if (isTypeBehavior)
+                    behaviorTypes.Add(type);
+            }
+
+            foreach (var (requestType, responseType) in requestResponseTypes)
+            {
+                var typeArgs = new[] {requestType, responseType};
+                var closedInterfaceType = typeof(IPipelineBehavior<,>).MakeGenericType(typeArgs);
+
+                foreach (var behaviorType in behaviorTypes)
+                {
+                    var closedImplementationType = behaviorType.MakeGenericType(responseType);
+                    services.AddTransient(closedInterfaceType, closedImplementationType);
+                }
+            }
+        }
+        private static Type GetRequestInterfaceType(Type pluggedType, Type pluginType)
+        {
+            return pluggedType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == pluginType);
+        }
+        
+        private static bool IsConcrete(this Type type)
+        {
+            return !type.GetTypeInfo().IsAbstract && !type.GetTypeInfo().IsInterface;
+        }
+    }
+}

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -90,5 +90,29 @@ namespace MediatR
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration> configuration)
             => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration);
+        
+        /// <summary>
+        /// Registers behaviors that should react on requests that implement type <typeparam name="T"></typeparam> from the assemblies that contain the specified types
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="handlerAssemblyMarkerTypes"></param>
+        /// <typeparam name="T">Type that requests should implement</typeparam>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddBehaviorsForRequest<T>(this IServiceCollection services,
+            params Type[] handlerAssemblyMarkerTypes)
+            where T : class
+        {
+            var assemblies = handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly).ToArray();
+
+            if (!assemblies.Any())
+            {
+                throw new ArgumentException(
+                    "No assemblies found to scan. Supply at least one assembly to scan for handlers.");
+            }
+
+            BehaviorRegistrar.RegisterBehaviorForCovariantRequest(typeof(T), services, assemblies);
+
+            return services;
+        }
     }
 }


### PR DESCRIPTION
Hi!

When I use MediatR I miss one important feature. I want to register **Behaviors** not only for certain **Request** and **Response** or for generic **TRequest** and **TResponse**. But I also want behaviors that triggers on some generic request. I think the best way to explain what I want is to show the code:

```
public interface ICommon { }

public class MyRequest1 : ICommon, IRequest<string> { }

public class MyRequest2 : ICommon, IRequest<int> { }

public class MyRequest3 : IRequest<int> { }
```

So I want to register some behavior that triggers only on requests that implement **ICommon**:

```
public class InterfaceBehavior<T> : IPipelineBehavior<ICommon, T>
{
    public async Task<T> Handle(ICommon request, CancellationToken cancellationToken, RequestHandlerDelegate<T> next)
    {
        return await next();
    }
}
```

With standard **Microsoft.DependecyInjection** I could not do such a thing. So I wrote an extension method that sort through all request that implement **ICommon** and register behavior for them. It looks like:

`services.AddBehaviorsForRequest<ICommon>(typeof(Startup));`

Maybe my implementation is naive and does not take into account corner cases but I think it is better than nothing.

If you accept my idea I can add tests for this functional.