### PR TITLE
Type should have same number of generic Parameters

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
@@ -30,7 +30,7 @@ namespace MediatR.Registration
                 typeof(IRequestExceptionAction<,>)
             };
 
-            foreach (var multiOpenInterface in multiOpenInterfaces)
+            foreach (TypeInfo multiOpenInterface in multiOpenInterfaces)
             {
                 var concretions = assembliesToScan
                     .SelectMany(a => a.DefinedTypes)
@@ -40,9 +40,16 @@ namespace MediatR.Registration
 
                 foreach (var type in concretions)
                 {
+                    if(type.GenericTypeParameters.Length != multiOpenInterface.GenericTypeParameters.Length)
+                    {
+                        continue;
+                    }
                     services.AddTransient(multiOpenInterface, type);
                 }
             }
+
+
+            
         }
 
         /// <summary>

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
@@ -47,9 +47,6 @@ namespace MediatR.Registration
                     services.AddTransient(multiOpenInterface, type);
                 }
             }
-
-
-            
         }
 
         /// <summary>


### PR DESCRIPTION
Found a situation where a generic type doesn't have the entire number of parameter to satisfy.

take this type for example:

```
    public class HandlerAdapter<THandler, TRequest> : INotificationHandler<TRequest>
        where TRequest : INotification
        where THandler : ISomeOtherStuff<TRequest>
    {
        private readonly THandler innerStuff;

        public HandlerShim(THandler innerStuff)
        {
            this.innerStuff = innerStuff;
        }

        public async Task Handle(TRequest notification, CancellationToken cancellationToken)
        {
            await innerStuff.Stuff(notification);
        }
    }
```

results in the following exception being thrown: System.ArgumentException: 'The number of generic arguments provided doesn't equal the arity of the generic type definition. (Parameter 'instantiation')'
