### PR TITLE
Added option to pass a function to evaluate types for binding

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
@@ -6,6 +6,7 @@ namespace MediatR
 
     public class MediatRServiceConfiguration
     {
+        public Func<Type, bool> TypeEvaluator { get; private set; } = t => true;
         public Type MediatorImplementationType { get; private set; }
         public ServiceLifetime Lifetime { get; private set; }
 
@@ -36,6 +37,12 @@ namespace MediatR
         public MediatRServiceConfiguration AsTransient()
         {
             Lifetime = ServiceLifetime.Transient;
+            return this;
+        }
+
+        public MediatRServiceConfiguration WithEvaluator(Func<Type, bool> evaluator)
+        {
+            TypeEvaluator = evaluator;
             return this;
         }
     }

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace MediatR
         /// <param name="assemblies">Assemblies to scan</param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Assembly[] assemblies)
-            => services.AddMediatR(assemblies, configuration: null);
+            => services.AddMediatR(assemblies, configuration: null, null);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
@@ -36,7 +36,7 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration> configuration, params Assembly[] assemblies)
-            => services.AddMediatR(assemblies, configuration);
+            => services.AddMediatR(assemblies, configuration, null);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
@@ -45,7 +45,7 @@ namespace MediatR
         /// <param name="assemblies">Assemblies to scan</param>
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration> configuration)
+        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration> configuration, Func<Type, bool> typeEvaluator = null)
         {
             if (!assemblies.Any())
             {
@@ -57,7 +57,7 @@ namespace MediatR
 
             ServiceRegistrar.AddRequiredServices(services, serviceConfig);
 
-            ServiceRegistrar.AddMediatRClasses(services, assemblies);
+            ServiceRegistrar.AddMediatRClasses(services, assemblies, typeEvaluator);
 
             return services;
         }
@@ -69,7 +69,7 @@ namespace MediatR
         /// <param name="handlerAssemblyMarkerTypes"></param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Type[] handlerAssemblyMarkerTypes)
-            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration: null);
+            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration: null, typeEvaluator: null);
         
         /// <summary>
         /// Registers handlers and mediator types from the assemblies that contain the specified types
@@ -79,7 +79,7 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration> configuration, params Type[] handlerAssemblyMarkerTypes)
-            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration);
+            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration, typeEvaluator: null);
 
         /// <summary>
         /// Registers handlers and mediator types from the assemblies that contain the specified types
@@ -89,6 +89,27 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration> configuration)
-            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration);
+            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration, typeEvaluator: null);
+
+        /// <summary>
+        /// Registers handlers and mediator types from the assemblies that contain the specified types
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="handlerAssemblyMarkerTypes"></param>
+        /// <param name="configuration">The action used to configure the options</param>
+        /// <param name="typeEvaluator">Function to evaluate types, used to include/exclude namespaces</param>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration> configuration, Func<Type, bool> typeEvaluator)
+            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration, typeEvaluator);
+
+        /// <summary>
+        /// Registers handlers and mediator types from the specified assemblies, excluding specified namespaces
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="assemblies">Assemblies to scan</param>
+        /// <param name="typeEvaluator">Function to evaluate types, used to include/exclude namespaces</param>
+        /// <returns>Service collection</returns>
+        public static IServiceCollection AddMediatR(this IServiceCollection services, Assembly[] assemblies, Func<Type, bool> typeEvaluator)
+            => services.AddMediatR(assemblies, configuration: null, typeEvaluator);
     }
 }

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace MediatR
         /// <param name="assemblies">Assemblies to scan</param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Assembly[] assemblies)
-            => services.AddMediatR(assemblies, configuration: null, null);
+            => services.AddMediatR(assemblies, configuration: null);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
@@ -36,7 +36,7 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration> configuration, params Assembly[] assemblies)
-            => services.AddMediatR(assemblies, configuration, null);
+            => services.AddMediatR(assemblies, configuration);
 
         /// <summary>
         /// Registers handlers and mediator types from the specified assemblies
@@ -45,7 +45,7 @@ namespace MediatR
         /// <param name="assemblies">Assemblies to scan</param>
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration> configuration, Func<Type, bool> typeEvaluator = null)
+        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration> configuration)
         {
             if (!assemblies.Any())
             {
@@ -57,7 +57,7 @@ namespace MediatR
 
             ServiceRegistrar.AddRequiredServices(services, serviceConfig);
 
-            ServiceRegistrar.AddMediatRClasses(services, assemblies, typeEvaluator);
+            ServiceRegistrar.AddMediatRClasses(services, assemblies, serviceConfig);
 
             return services;
         }
@@ -69,7 +69,7 @@ namespace MediatR
         /// <param name="handlerAssemblyMarkerTypes"></param>        
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, params Type[] handlerAssemblyMarkerTypes)
-            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration: null, typeEvaluator: null);
+            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration: null);
         
         /// <summary>
         /// Registers handlers and mediator types from the assemblies that contain the specified types
@@ -79,7 +79,7 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration> configuration, params Type[] handlerAssemblyMarkerTypes)
-            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration, typeEvaluator: null);
+            => services.AddMediatR(handlerAssemblyMarkerTypes, configuration);
 
         /// <summary>
         /// Registers handlers and mediator types from the assemblies that contain the specified types
@@ -89,27 +89,6 @@ namespace MediatR
         /// <param name="configuration">The action used to configure the options</param>
         /// <returns>Service collection</returns>
         public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration> configuration)
-            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration, typeEvaluator: null);
-
-        /// <summary>
-        /// Registers handlers and mediator types from the assemblies that contain the specified types
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="handlerAssemblyMarkerTypes"></param>
-        /// <param name="configuration">The action used to configure the options</param>
-        /// <param name="typeEvaluator">Function to evaluate types, used to include/exclude namespaces</param>
-        /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration> configuration, Func<Type, bool> typeEvaluator)
-            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration, typeEvaluator);
-
-        /// <summary>
-        /// Registers handlers and mediator types from the specified assemblies, excluding specified namespaces
-        /// </summary>
-        /// <param name="services">Service collection</param>
-        /// <param name="assemblies">Assemblies to scan</param>
-        /// <param name="typeEvaluator">Function to evaluate types, used to include/exclude namespaces</param>
-        /// <returns>Service collection</returns>
-        public static IServiceCollection AddMediatR(this IServiceCollection services, Assembly[] assemblies, Func<Type, bool> typeEvaluator)
-            => services.AddMediatR(assemblies, configuration: null, typeEvaluator);
+            => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration);
     }
 }

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/Handlers.cs
@@ -169,5 +169,39 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
             throw new System.NotImplementedException();
         }
     }
+}
 
+namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class Foo : IRequest<Bar>
+    {
+        public string Message { get; set; }
+        public Action<Foo> ThrowAction { get; set; }
+    }
+
+    public class Bar
+    {
+        public string Message { get; set; }
+    }
+
+    public class FooHandler : IRequestHandler<Foo, Bar>
+    {
+        private readonly Logger _logger;
+
+        public FooHandler(Logger logger)
+        {
+            _logger = logger;
+        }
+        public Task<Bar> Handle(Foo message, CancellationToken cancellationToken)
+        {
+            _logger.Messages.Add("Handler");
+
+            message.ThrowAction?.Invoke(message);
+
+            return Task.FromResult(new Bar { Message = message.Message + " Bar" });
+        }
+    }
 }

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/TypeEvaluatorTests.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/TypeEvaluatorTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included;
+    using Shouldly;
+    using Xunit;
+
+    public class TypeEvaluatorTests
+    {
+        private readonly IServiceProvider _provider;
+
+        public TypeEvaluatorTests()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+            services.AddMediatR(new[] { typeof(Ping).GetTypeInfo().Assembly }, t =>
+            {
+                return t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included";
+            });
+            _provider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void ShouldResolveMediator()
+        {
+            _provider.GetService<IMediator>().ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ShouldOnlyResolveIncludedRequestHandlers()
+        {
+            _provider.GetService<IRequestHandler<Foo, Bar>>().ShouldNotBeNull();
+            _provider.GetService<IRequestHandler<Ping, Pong>>().ShouldBeNull();
+        }
+    }
+}

--- a/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/TypeEvaluatorTests.cs
+++ b/test/MediatR.Extensions.Microsoft.DependencyInjection.Tests/TypeEvaluatorTests.cs
@@ -2,11 +2,10 @@
 
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included;
     using Shouldly;
+    using System;
+    using System.Reflection;
     using Xunit;
 
     public class TypeEvaluatorTests
@@ -17,9 +16,9 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
         {
             IServiceCollection services = new ServiceCollection();
             services.AddSingleton(new Logger());
-            services.AddMediatR(new[] { typeof(Ping).GetTypeInfo().Assembly }, t =>
+            services.AddMediatR(new[] { typeof(Ping).GetTypeInfo().Assembly }, cfg =>
             {
-                return t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included";
+                cfg.WithEvaluator(t => t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included");
             });
             _provider = services.BuildServiceProvider();
         }


### PR DESCRIPTION
Ref #106

Allows the consumer to pass a function to evaluate types considered for binding. This makes it possible to include/exclude on for example namespace.

I added a simple test to prove that it works. All other tests pass, proving that I did not mess anything up.