### PR TITLE
Add filter to skip registration of open generics with mismatched arity

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/ServiceRegistrar.cs
@@ -32,10 +32,13 @@ namespace MediatR.Registration
 
             foreach (var multiOpenInterface in multiOpenInterfaces)
             {
+                var arity = multiOpenInterface.GetGenericArguments().Length;
+
                 var concretions = assembliesToScan
                     .SelectMany(a => a.DefinedTypes)
                     .Where(type => type.FindInterfacesThatClose(multiOpenInterface).Any())
                     .Where(type => type.IsConcrete() && type.IsOpenGeneric())
+                    .Where(type => type.GetGenericArguments().Length == arity)
                     .ToList();
 
                 foreach (var type in concretions)


### PR DESCRIPTION
This PR addresses a recent change to the dotnet runtime, which now throws an exception upon the attempted registration of open generic types with a mismatched arity between service and implementation: https://github.com/dotnet/runtime/pull/51167

Since dotnet will now explicitly disallow the registration of these types, MediatR should not attempt to register them. 

I created this repo, https://github.com/markmillercc/MediatRClub, to provide more detail and to demonstrate how I've used these types of services successfully, and how to reproduce the error that occurs when upgrading the Microsoft packages.

Note: this problem can also be resolved via this open PR, which would allow for the exclusion of specified types: https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/pull/107

Related:  https://github.com/jbogard/MediatR/issues/674