### PR TITLE
Added ability to register additional interface implementations

### DIFF
--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/MediatrServiceConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Collections.Generic;
+using MediatR.Registration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR;
 
@@ -9,6 +11,7 @@ public class MediatRServiceConfiguration
     public Func<Type, bool> TypeEvaluator { get; private set; } = t => true;
     public Type MediatorImplementationType { get; private set; }
     public ServiceLifetime Lifetime { get; private set; }
+    public HashSet<TypeRegistration> AdditionalClasses { get; } = new();
     public RequestExceptionActionProcessorStrategy RequestExceptionActionProcessorStrategy { get; set; }
 
     public MediatRServiceConfiguration()

--- a/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/TypeRegistration.cs
+++ b/src/MediatR.Extensions.Microsoft.DependencyInjection/Registration/TypeRegistration.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace MediatR.Registration
+{
+    public class TypeRegistration
+    {
+        public TypeRegistration(Type interfaceType, bool singleImplementation = false)
+        {
+            if (!interfaceType.IsInterface)
+            {
+                throw new ArgumentException("Only interface types are allowed");
+            }
+
+            InterfaceType = interfaceType;
+            SingleImplementation = singleImplementation;
+        }
+
+        public Type InterfaceType { get; }
+        public bool SingleImplementation { get; }
+
+        protected bool Equals(TypeRegistration other)
+        {
+            return InterfaceType == other.InterfaceType;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((TypeRegistration) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return InterfaceType.GetHashCode();
+        }
+
+        public static bool operator ==(TypeRegistration? left, TypeRegistration? right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(TypeRegistration? left, TypeRegistration? right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Internal DI discovery MediatR mechanism is black box for others. This PR adds ability to use same rules for additional custom types. Feature can be useful for validators and other behavior extensions.

# Example

[FluentValidation](https://fluentvalidation.net/) integration into pipeline without additional manual validators registration.

## Behavior extension

Pre handle validation behavior

```CSharp
public class RequestValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
{
    private readonly IEnumerable<IValidator<TRequest>> _validators;

    public RequestValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
    {
        _validators = validators;
    }

    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
    {
        foreach (var validator in _validators)
        {
            await validator.ValidateAndThrowAsync(request, cancellationToken);
        }
        
        return await next();
    }
}
```

## DI registration

```CSharp
var provider = new ServiceCollection()
                .AddMediatR(config =>
                {
                    config.AdditionalClasses.Add(new TypeRegistration(typeof(IValidator<>)));
                }, typeof(Ping));
                .AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
                .BuildServiceProvider();
```

## Handler, Request and Validator implementation

```CSharp
public class CustomRequest : IRequest<bool>
{
    public string Title { get; set; }
}

public class CustomRequestValidator : AbstractValidator<CustomRequest>
{
    public CustomRequestValidator()
    {
        RuleFor(x => x.Title)
            .NotEmpty();
    }
}

public class CustomRequestHandler : IRequestHandler<CustomRequest, bool>
{
    public async Task<bool> Handle(CustomRequest request, CancellationToken cancellationToken)
    {
        await Task.Delay(0, cancellationToken);
        return true;
    }
}
```

## Usage

```CSharp
var mediator = provider.GetRequiredService<IMediator>();
var result = await mediator.Send(new CustomRequest());
```