### PR TITLE
docs: Update README with lifetimes of IPublisher and ISender

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ services.AddMediatR(typeof(Startup).GetTypeInfo().Assembly);
 This registers:
 
 - `IMediator` as transient
+- `ISender` as transient
+- `IPublisher` as transient
 - `IRequestHandler<>` concrete implementations as transient
 - `INotificationHandler<>` concrete implementations as transient
 - `IStreamRequestHandler<>` concrete implementations as transient


### PR DESCRIPTION
I noticed the lifetimes of `IPublisher` and `ISender` (from MediatR 9) were missing in the registration list in the README.
This adds them.